### PR TITLE
adding netgroup support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/getent/__init__.py
+++ b/getent/__init__.py
@@ -317,10 +317,6 @@ class Netgroup(StructMap):
 
     def __init__(self, p):
         super(Netgroup, self).__init__(p)
-        #self.members = list(self._map('members'))
-
-    #def __getitem__(self, key):
-    #    return self.p[key]
 
 
 class Group(StructMap):

--- a/getent/__init__.py
+++ b/getent/__init__.py
@@ -127,16 +127,8 @@ class StructMap(object):
             yield convert23(obj[i])
             i += 1
 
-#    def __repr__(self):
-#        out = {}
-#        for attr in dir(self.p):
-#            if attr.startswith('_'):
-#                continue
-#
-#            else:
-#                out.update({attr:getattr(self, attr)})
-#        return str(out)
-        
+    def __getitem__(self, attr):
+        return self.p[attr]
 
 
 def _resolve(addrtype, addr):
@@ -326,7 +318,9 @@ class Netgroup(StructMap):
     def __init__(self, p):
         super(Netgroup, self).__init__(p)
         #self.members = list(self._map('members'))
-    #pass
+
+    #def __getitem__(self, key):
+    #    return self.p[key]
 
 
 class Group(StructMap):
@@ -693,9 +687,9 @@ def netgroup(netgroup,host=None,user=None,domain=None):
 
     To lookup one group by netgroup name::
 
-        >>> @netgroup = netgroup()
-        >>> print root.name
-        'root'
+        >>> ng = netgroup(netgroupname)
+        >>> print ng.name
+        'netgroupname'
 
     """
     host,user,domain = c_char_p(None),c_char_p(None),c_char_p(None)
@@ -708,7 +702,6 @@ def netgroup(netgroup,host=None,user=None,domain=None):
     else:
         # True or False
         netgrp = setnetgrent(netgroup)
-        res = []
         members = []
         while netgrp:
             # getnetgrent need pointers to be written
@@ -717,8 +710,7 @@ def netgroup(netgroup,host=None,user=None,domain=None):
                 #res.append(Netgroup(netgrp))
                 members.append({ 'host':host.value,'user':user.value,'domain':domain.value })
         endnetgrent()
-        res.append(Netgroup({'name':netgroup,'members':members}))
-        return res
+        return Netgroup({'name':netgroup,'members':members})
 
 
 def group(search=None):

--- a/getent/__init__.py
+++ b/getent/__init__.py
@@ -7,7 +7,6 @@ import struct
 import sys
 from ctypes import POINTER, cast, create_string_buffer, pointer, byref as _byref
 from datetime import datetime
-from pprint import pprint
 
 from getent import headers
 from getent.constants import (
@@ -93,14 +92,10 @@ class StructMap(object):
         Will also define getter and setter attributes on the instance for all
         struct members.
         """
-        #pprint(dir(self))
         if(hasattr(p, "contents")):
             self.p = p.contents
         else:
-            pprint("qui")
             self.p = p
-        pprint("regex")
-        pprint(dir(self.p))
 
         for attr in dir(self.p):
 
@@ -108,34 +103,24 @@ class StructMap(object):
                 continue
 
             elif not hasattr(self, attr):
-                print("quo")
                 value = getattr(self.p, attr)
                 setattr(self, attr, convert23(value))
-                print("qua %s %s" % (attr, value))
 
     def __iter__(self):
         """Iterate over the mapped struct members.
 
         Yields `(key, value)` pairs.
         """
-        #pprint(dir(self))
-        #for attr in dir(self.p.contents):
-        print("ppri")
         for attr in dir(self.p):
             if attr.startswith('_'):
                 continue
 
             else:
-                print("ppro")
                 yield (attr, getattr(self, attr))
-                print("ppra %s" % attr)
 
     def _map(self, attr):
-        #pprint(dir(self))
         i = 0
         #obj = getattr(self.p.contents, attr)
-        print("qpri")
-        pprint(dir(self))
         obj = getattr(self.p, attr)
 
         while obj[i]:
@@ -149,12 +134,8 @@ class StructMap(object):
 #                continue
 #
 #            else:
-#                print("ypro")
 #                out.update({attr:getattr(self, attr)})
-#                print("ypra %s" % attr)
 #        return str(out)
-#
-#       #return str(self)
         
 
 

--- a/getent/headers.py
+++ b/getent/headers.py
@@ -12,6 +12,7 @@ from getent.constants import size_t, uint8_t, uint16_t, uint32_t
 __all__ = (
     'AliasStruct',
     'GroupStruct',
+    'NetgroupStruct',
     'HostStruct',
     'InAddr6Struct',
     'InAddr6Union',

--- a/getent/headers.py
+++ b/getent/headers.py
@@ -129,6 +129,18 @@ class ServiceStruct(Structure):
     ]
 
 
+class NetgroupStruct(Structure):
+
+    """Struct `netgroup` from `<netgroup.h>`."""
+
+    _fields_ = [
+        ("name", ctypes_c_char_p),
+        ("host", ctypes_c_char_p),
+        ("user", ctypes_c_char_p),
+        ("domain", ctypes_c_char_p),
+    ]
+
+
 class GroupStruct(Structure):
 
     """Struct `group` from `<grp.h>`."""

--- a/getent/libc.py
+++ b/getent/libc.py
@@ -11,6 +11,7 @@ from getent.constants import ctypes_c_char_p, gid_t, uid_t
 
 __all__ = (
     'endgrent',
+    'endnetgrent',
     'endhostent',
     'endnetent',
     'endprotoent',
@@ -19,6 +20,7 @@ __all__ = (
     'endservent',
     'endspent',
     'getgrent',
+    'getnetgrent',
     'getgrgid',
     'getgrnam',
     'gethostbyaddr',
@@ -42,6 +44,7 @@ __all__ = (
     'inet_pton',
     'libc',
     'setgrent',
+    'setnetgrent',
     'sethostent',
     'setnetent',
     'setprotoent',
@@ -115,6 +118,16 @@ else:
     endservent = None
     getservent = None
     setservent = None
+
+if hasattr(libc, 'getnetgrent'):
+    endnetgrent = libc.endnetgrent
+    getnetgrent = libc.getnetgrent
+    getnetgrent.restype = POINTER(headers.NetgroupStruct)
+    setnetgrent = libc.setnetgrent
+else:
+    endnetgrent = None
+    getnetgrent = None
+    setnetgrent = None
 
 if hasattr(libc, 'getgrent'):
     endgrent = libc.endgrent

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ skip_missing_interpreters = true
 
 [testenv]
 usedevelop=true
-deps=-rrequirements-test.txt
+deps=-r{toxinidir}/requirements-test.txt
 commands = py.test --verbose --verbose --cov getent {posargs}


### PR DESCRIPTION
netgroup support added.
The glibc structure is totally different, so the main class has been modified to immediately extract  .contents into p, as checking the other data seems to me not relevant - but i can be wrong of course.

what do you think about it?